### PR TITLE
Remove omitempty as it makes it impossible to request block 0

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -33,7 +33,7 @@ type EngineBlock struct {
 }
 
 type blockChainQueryParams struct {
-	BlockNumber int `json:"blockNumber,omitempty"`
+	BlockNumber int `json:"blockNumber"`
 }
 
 func (h HiveEngineRpcNode) GetStatus() (*EngineStatus, error) {


### PR DESCRIPTION
OmitEmpty is set on the getBlockInfo struct, making it turn into an empty struct when requesting block 0, making it impossible to do so.